### PR TITLE
Fix Eastern-related holidays in France

### DIFF
--- a/src/Cmixin/Holidays/fr-national.php
+++ b/src/Cmixin/Holidays/fr-national.php
@@ -12,13 +12,13 @@ return array(
     '01/05', // Fête du travail
     '08/05', // Victoire 1945
     function ($year) { // Ascension
-        $days = easter_days($year) + 40;
+        $days = easter_days($year) + 39;
         $date = new DateTime("$year-03-21 +$days days");
 
         return $date->format('d/m');
     },
     function ($year) { // Lundi de Pentecôte
-        $days = easter_days($year) + 51;
+        $days = easter_days($year) + 50;
         $date = new DateTime("$year-03-21 +$days days");
 
         return $date->format('d/m');

--- a/tests/Cmixin/BusinessDayTest.php
+++ b/tests/Cmixin/BusinessDayTest.php
@@ -344,7 +344,7 @@ class BusinessDayTest extends TestCase
         self::assertSame('16/04/2018', $carbon::parse('2018-04-15 12:00:00')->addBusinessDays()->format('d/m/Y'));
         self::assertSame('17/04/2018', $carbon::parse('2018-04-16 12:00:00')->addBusinessDays()->format('d/m/Y'));
         self::assertSame('12/11/2018', $carbon::parse('2018-11-11 12:00:00')->addBusinessDays()->format('d/m/Y'));
-        self::assertSame('10/05/2018', $carbon::parse('2018-05-01 12:00:00')->addBusinessDays(6)->format('d/m/Y'));
+        self::assertSame('11/05/2018', $carbon::parse('2018-05-01 12:00:00')->addBusinessDays(6)->format('d/m/Y'));
         self::assertSame('17/04/2018', $carbon::parse('2018-04-04 12:00:00')->addBusinessDays(9)->format('d/m/Y'));
         self::assertSame('24/05/2018', $carbon::parse('2018-04-14 12:00:00')->addBusinessDays(25)->format('d/m/Y'));
         self::assertSame('18/04/2018', $carbon::parse('2018-04-15 12:00:00')->addBusinessDays(3)->format('d/m/Y'));

--- a/tests/Cmixin/Holidays/FrTest.php
+++ b/tests/Cmixin/Holidays/FrTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Cmixin\Holidays;
+
+use Cmixin\BusinessDay;
+use PHPUnit\Framework\TestCase;
+
+class FrTest extends TestCase
+{
+    const CARBON_CLASS = 'Carbon\Carbon';
+
+    protected function setUp()
+    {
+        BusinessDay::enable(static::CARBON_CLASS);
+        $carbon = static::CARBON_CLASS;
+        $carbon::resetHolidays();
+    }
+
+    public function testHolidaysSpecificDates()
+    {
+        $carbon = static::CARBON_CLASS;
+        $carbon::setHolidaysRegion('fr-national');
+
+        // 2018 year
+        self::assertTrue($carbon::parse('2018-01-01')->isHoliday()); // New Year
+        self::assertTrue($carbon::parse('2018-01-06')->isHoliday()); // Epiphany
+        self::assertTrue($carbon::parse('2018-04-02')->isHoliday()); // Eastern Monday
+        self::assertTrue($carbon::parse('2018-05-01')->isHoliday()); // Labor Day
+        self::assertTrue($carbon::parse('2018-05-08')->isHoliday()); // Victory 1945
+        self::assertTrue($carbon::parse('2018-05-10')->isHoliday()); // Ascension Thursday
+        self::assertTrue($carbon::parse('2018-05-21')->isHoliday()); // Whit Monday
+        self::assertTrue($carbon::parse('2018-07-14')->isHoliday()); // National Holiday
+        self::assertTrue($carbon::parse('2018-08-15')->isHoliday()); // Assomption
+        self::assertTrue($carbon::parse('2018-11-01')->isHoliday()); // All Saints
+        self::assertTrue($carbon::parse('2018-11-11')->isHoliday()); // Armistice 1918
+        self::assertTrue($carbon::parse('2018-12-25')->isHoliday()); // Christmas
+
+        // 2019 year
+        self::assertTrue($carbon::parse('2019-01-01')->isHoliday()); // New Year
+        self::assertTrue($carbon::parse('2019-01-06')->isHoliday()); // Epiphany
+        self::assertTrue($carbon::parse('2019-04-22')->isHoliday()); // Eastern Monday
+        self::assertTrue($carbon::parse('2019-05-01')->isHoliday()); // Labor Day
+        self::assertTrue($carbon::parse('2019-05-08')->isHoliday()); // Victory 1945
+        self::assertTrue($carbon::parse('2019-05-30')->isHoliday()); // Ascension Thursday
+        self::assertTrue($carbon::parse('2019-06-10')->isHoliday()); // Whit Monday
+        self::assertTrue($carbon::parse('2019-07-14')->isHoliday()); // National Holiday
+        self::assertTrue($carbon::parse('2019-08-15')->isHoliday()); // Assomption
+        self::assertTrue($carbon::parse('2019-11-01')->isHoliday()); // All Saints
+        self::assertTrue($carbon::parse('2019-11-11')->isHoliday()); // Armistice 1918
+        self::assertTrue($carbon::parse('2019-12-25')->isHoliday()); // Christmas
+    }
+}


### PR DESCRIPTION
It fixes calculation for some holidays in France. According to for example https://www.joursferies.fr:

Ascension -> should be 10 May in 2018
Lundi de Pentecôte -> should be 21 May in 2018