### PR TITLE
German holidays (national + all states)

### DIFF
--- a/src/Cmixin/Holidays/de-be.php
+++ b/src/Cmixin/Holidays/de-be.php
@@ -2,6 +2,4 @@
 
 return array_replace(require __DIR__.'/de-national.php', [
     '03-08'     => '03-08',
-    'easter'    => '= easter',
-    'easter-49' => '= easter 49',
 ]);

--- a/src/Cmixin/Holidays/de-bw.php
+++ b/src/Cmixin/Holidays/de-bw.php
@@ -2,8 +2,6 @@
 
 return array_replace(require __DIR__.'/de-national.php', [
     '01-06'     => '01-06',
-    'easter-3'  => '= easter -3',
     'easter-60' => '= easter 60',
-    '10-31'     => '10-31',
     '11-01'     => '11-01',
 ]);

--- a/src/Cmixin/Holidays/de-by.php
+++ b/src/Cmixin/Holidays/de-by.php
@@ -2,9 +2,7 @@
 
 return array_replace(require __DIR__.'/de-national.php', [
     '01-06'                  => '01-06',
-    '02-02'                  => '02-02',
     'easter-60'              => '= easter 60',
     '08-15'                  => '08-15',
     '11-01'                  => '11-01',
-    'wednesday-before-11-23' => '= Wednesday before 11-23',
 ]);

--- a/src/Cmixin/Holidays/de-hb.php
+++ b/src/Cmixin/Holidays/de-hb.php
@@ -1,6 +1,5 @@
 <?php
 
 return array_replace(require __DIR__.'/de-national.php', [
-    '12-31-14:00' => '= 12-31 14:00 if Sunday then 00:00',
     '10-31'       => '10-31',
 ]);

--- a/src/Cmixin/Holidays/de-he.php
+++ b/src/Cmixin/Holidays/de-he.php
@@ -2,5 +2,4 @@
 
 return array_replace(require __DIR__.'/de-national.php', [
     'easter-60'   => '= easter 60',
-    '12-31-14:00' => '= 12-31 14:00 if Sunday then 00:00',
 ]);

--- a/src/Cmixin/Holidays/de-national.php
+++ b/src/Cmixin/Holidays/de-national.php
@@ -10,27 +10,6 @@ return [
     'easter-50'               => '= easter 50',
     '10-03'                   => '10-03',
     '11-11'                   => '11-11',
-    'wednesday-before-11-23'  => '= Wednesday before 11-23',
-    '6th-sunday-before-12-25' => '= Sunday before 11-20',
-    '5th-sunday-before-12-25' => '= Sunday before 11-27',
-    '4th-sunday-before-12-25' => '= Sunday before 12-04',
-    '3th-sunday-before-12-25' => '= Sunday before 12-11',
-    '2nd-sunday-before-12-25' => '= Sunday before 12-18',
-    '1st-sunday-before-12-25' => '= Sunday before 12-25',
     'christmas'               => '12-25',
     'christmas-next-day'      => '12-26',
-    '2017-10-31'              => '= 2017-10-31',
 ];
-
-removed 02-14: Valentinstag: no public holiday in any German state
-removed easter-52: Weiberfastnacht: no public holiday in any German state
-removed easter-48: Rosenmontag: no public holiday in any German state
-removed easter-46: Aschermittwoch: no public holiday in any German state
-removed easter-3: Gründonnerstag: no public holiday in any German state
-removed 2nd-sunday-of-may: Muttertag:  no public holiday in any German state, but anyway always on a sunday
-removed easter-49: Pfingstsonntag: no public holiday in most German states
-removed 11-01: Allerheiligen: no public holiday in most German states
-removed 11-02: no name, no public holiday in any German state
-
-
-https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland

--- a/src/Cmixin/Holidays/de-national.php
+++ b/src/Cmixin/Holidays/de-national.php
@@ -2,22 +2,13 @@
 
 return [
     'new-year'                => '01-01',
-    '02-14'                   => '02-14',
-    'easter-52'               => '= easter -52',
-    'easter-48'               => '= easter -48',
-    'easter-46'               => '= easter -46',
-    'easter-3'                => '= easter -3',
     'easter-2'                => '= easter -2',
     'easter'                  => '= easter',
     'easter-p1'               => '= easter 1',
     '05-01'                   => '05-01',
-    '2nd-sunday-of-may'       => '= second Sunday of May',
     'easter-39'               => '= easter 39',
-    'easter-49'               => '= easter 49',
     'easter-50'               => '= easter 50',
     '10-03'                   => '10-03',
-    '11-01'                   => '11-01',
-    '11-02'                   => '11-02',
     '11-11'                   => '11-11',
     'wednesday-before-11-23'  => '= Wednesday before 11-23',
     '6th-sunday-before-12-25' => '= Sunday before 11-20',
@@ -30,3 +21,16 @@ return [
     'christmas-next-day'      => '12-26',
     '2017-10-31'              => '= 2017-10-31',
 ];
+
+removed 02-14: Valentinstag: no public holiday in any German state
+removed easter-52: Weiberfastnacht: no public holiday in any German state
+removed easter-48: Rosenmontag: no public holiday in any German state
+removed easter-46: Aschermittwoch: no public holiday in any German state
+removed easter-3: Gründonnerstag: no public holiday in any German state
+removed 2nd-sunday-of-may: Muttertag:  no public holiday in any German state, but anyway always on a sunday
+removed easter-49: Pfingstsonntag: no public holiday in most German states
+removed 11-01: Allerheiligen: no public holiday in most German states
+removed 11-02: no name, no public holiday in any German state
+
+
+https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland

--- a/src/Cmixin/Holidays/de-sn.php
+++ b/src/Cmixin/Holidays/de-sn.php
@@ -1,7 +1,6 @@
 <?php
 
 return array_replace(require __DIR__.'/de-national.php', [
-    'easter-60'              => '= easter 60',
     '10-31'                  => '10-31',
     'wednesday-before-11-23' => '= Wednesday before 11-23',
 ]);

--- a/src/Cmixin/Holidays/de-th.php
+++ b/src/Cmixin/Holidays/de-th.php
@@ -1,7 +1,6 @@
 <?php
 
 return array_replace(require __DIR__.'/de-national.php', [
-    'easter-60'   => '= easter 60',
+    '09-20'       => '09-20',
     '10-31'       => '10-31',
-    '12-31-14:00' => '= 12-31 14:00 if Sunday then 00:00',
 ]);


### PR DESCRIPTION
adjusted German holidays according to https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland

Holidays which are not in a whole state are not considered (only exception: 15.08. in BY. Since it is a holiday in 1704 municipalities and only in 352 municipalities not, I chose to leave it as a holiday for BY)