### PR TITLE
Add name for holiday after easter

### DIFF
--- a/src/Cmixin/HolidayNames/de.php
+++ b/src/Cmixin/HolidayNames/de.php
@@ -60,6 +60,7 @@ return [
     'easter-2'                                        => 'Karfreitag',
     'easter-1'                                        => 'Karsamstag',
     'easter'                                          => 'Ostersonntag',
+    'easter-p1'                                       => 'Ostermontag',
     'easter-49'                                       => 'Pfingstsonntag',
     'easter-50'                                       => 'Pfingstmontag',
     'easter-60'                                       => 'Fronleichnam',


### PR DESCRIPTION
In Germany, the day after easter (Sunday) is also a public holiday (Monday), called *Ostermontag*. This holiday is already defined as `easter-p1` in `src/Cmixin/Holidays/de-national.php` but the name was missing in `src/Cmixin/HolidayNames/de.php`.