### PR TITLE
Update Queens Birthday dates for AU

### DIFF
--- a/src/Cmixin/Holidays/au-act.php
+++ b/src/Cmixin/Holidays/au-act.php
@@ -3,6 +3,7 @@
 return array_replace(require __DIR__.'/au-national.php', [
     '2nd-monday-of-march'   => '= second Monday of March',
     'easter'                => '= easter',
+    '2nd-monday-of-june' => '= second Monday of June',
     'monday-before-10-01'   => '= Monday before 10-01',
     '1st-monday-of-october' => '= first Monday of October',
 ]);

--- a/src/Cmixin/Holidays/au-act.php
+++ b/src/Cmixin/Holidays/au-act.php
@@ -3,7 +3,7 @@
 return array_replace(require __DIR__.'/au-national.php', [
     '2nd-monday-of-march'   => '= second Monday of March',
     'easter'                => '= easter',
-    '2nd-monday-of-june' => '= second Monday of June',
+    '2nd-monday-of-june'    => '= second Monday of June',
     'monday-before-10-01'   => '= Monday before 10-01',
     '1st-monday-of-october' => '= first Monday of October',
 ]);

--- a/src/Cmixin/Holidays/au-national.php
+++ b/src/Cmixin/Holidays/au-national.php
@@ -7,7 +7,6 @@ return [
     'easter-p1'          => '= easter 1',
     'easter'             => '= easter',
     '04-25-and'          => '= 04-25 substitute',
-    '2nd-monday-of-june' => '= second Monday of June',
     '12-24'              => '12-24',
     '12-25-and'          => '= 12-25 if Saturday then next Monday',
     'substitutes-12-25'  => '= 12-25 if Sunday then next Tuesday',

--- a/src/Cmixin/Holidays/au-nsw.php
+++ b/src/Cmixin/Holidays/au-nsw.php
@@ -2,6 +2,6 @@
 
 return array_replace(require __DIR__.'/au-national.php', [
     'easter'                => '= easter',
-    '2nd-monday-of-june' => '= second Monday of June',
+    '2nd-monday-of-june'    => '= second Monday of June',
     '1st-monday-of-october' => '= first Monday of October',
 ]);

--- a/src/Cmixin/Holidays/au-nsw.php
+++ b/src/Cmixin/Holidays/au-nsw.php
@@ -2,5 +2,6 @@
 
 return array_replace(require __DIR__.'/au-national.php', [
     'easter'                => '= easter',
+    '2nd-monday-of-june' => '= second Monday of June',
     '1st-monday-of-october' => '= first Monday of October',
 ]);

--- a/src/Cmixin/Holidays/au-nt.php
+++ b/src/Cmixin/Holidays/au-nt.php
@@ -2,5 +2,6 @@
 
 return array_replace(require __DIR__.'/au-national.php', [
     '1st-monday-of-may'    => '= first Monday of May',
+    '2nd-monday-of-june' => '= second Monday of June',
     '1st-monday-of-august' => '= first Monday of August',
 ]);

--- a/src/Cmixin/Holidays/au-nt.php
+++ b/src/Cmixin/Holidays/au-nt.php
@@ -2,6 +2,6 @@
 
 return array_replace(require __DIR__.'/au-national.php', [
     '1st-monday-of-may'    => '= first Monday of May',
-    '2nd-monday-of-june' => '= second Monday of June',
+    '2nd-monday-of-june'   => '= second Monday of June',
     '1st-monday-of-august' => '= first Monday of August',
 ]);

--- a/src/Cmixin/Holidays/au-sa.php
+++ b/src/Cmixin/Holidays/au-sa.php
@@ -2,6 +2,7 @@
 
 return array_replace(require __DIR__.'/au-national.php', [
     '2nd-monday-of-march' => '= second Monday of March',
+    '2nd-monday-of-june' => '= second Monday of June',
     '12-24-19:00'         => '= 12-24 19:00',
     '12-31-19:00'         => '= 12-31 19:00',
 ]);

--- a/src/Cmixin/Holidays/au-sa.php
+++ b/src/Cmixin/Holidays/au-sa.php
@@ -2,7 +2,7 @@
 
 return array_replace(require __DIR__.'/au-national.php', [
     '2nd-monday-of-march' => '= second Monday of March',
-    '2nd-monday-of-june' => '= second Monday of June',
+    '2nd-monday-of-june'  => '= second Monday of June',
     '12-24-19:00'         => '= 12-24 19:00',
     '12-31-19:00'         => '= 12-31 19:00',
 ]);

--- a/src/Cmixin/Holidays/au-tas.php
+++ b/src/Cmixin/Holidays/au-tas.php
@@ -2,6 +2,6 @@
 
 return array_replace(require __DIR__.'/au-national.php', [
     '2nd-monday-of-march' => '= second Monday of March',
-    '2nd-monday-of-june' => '= second Monday of June',
+    '2nd-monday-of-june'  => '= second Monday of June',
     'easter-1'            => '= easter -1',
 ]);

--- a/src/Cmixin/Holidays/au-tas.php
+++ b/src/Cmixin/Holidays/au-tas.php
@@ -2,5 +2,6 @@
 
 return array_replace(require __DIR__.'/au-national.php', [
     '2nd-monday-of-march' => '= second Monday of March',
+    '2nd-monday-of-june' => '= second Monday of June',
     'easter-1'            => '= easter -1',
 ]);

--- a/src/Cmixin/Holidays/au-vic.php
+++ b/src/Cmixin/Holidays/au-vic.php
@@ -3,5 +3,6 @@
 return array_replace(require __DIR__.'/au-national.php', [
     '2nd-monday-of-march'     => '= second Monday of March',
     'easter'                  => '= easter',
+    '2nd-monday-of-june' => '= second Monday of June',
     '1st-friday-before-10-04' => '= Friday before 10-04',
 ]);

--- a/src/Cmixin/Holidays/au-vic.php
+++ b/src/Cmixin/Holidays/au-vic.php
@@ -3,6 +3,6 @@
 return array_replace(require __DIR__.'/au-national.php', [
     '2nd-monday-of-march'     => '= second Monday of March',
     'easter'                  => '= easter',
-    '2nd-monday-of-june' => '= second Monday of June',
+    '2nd-monday-of-june'      => '= second Monday of June',
     '1st-friday-before-10-04' => '= Friday before 10-04',
 ]);


### PR DESCRIPTION
The AU National holidays file had the 2nd Monday of June listed as a public holiday. This was for Queen's Birthday.

This is a public holiday in all states **except** QLD and WA.

I've removed it from the national file and placed it into each of the applicable states.