### PR TITLE
fr-national: fix consistency of comments

### DIFF
--- a/src/Cmixin/Holidays/fr-national.php
+++ b/src/Cmixin/Holidays/fr-national.php
@@ -7,18 +7,26 @@ return [
         '67'   => 'east',
         '68'   => 'east',
     ],
-    'new-year'         => '01/01', // Jour de l'an
+    // Jour de l'an
+    'new-year'         => '01/01',
     // Lundi de Pâques
     'easter-monday'    => '= easter + 1',
-    'labor-day'        => '01/05', // Fête du travail
-    'victory-1945'     => '08/05', // Victoire 1945
+    // Fête du travail
+    'labor-day'        => '01/05',
+    // Victoire 1945
+    'victory-1945'     => '08/05',
     // Ascension
     'ascension'        => '= easter + 39',
     // Lundi de Pentecôte
     'pentecost-monday' => '= easter + 50',
-    'national-day'     => '14/07', // Fête nationale
-    'assumption'       => '15/08', // Assomption
-    'toussaint'        => '01/11', // Toussaint
-    'armistice-1918'   => '11/11', // Armistice 1918
-    'christmas'        => '25/12', // Noël
+    // Fête nationale
+    'national-day'     => '14/07',
+    // Assomption
+    'assumption'       => '15/08',
+    // Toussaint
+    'toussaint'        => '01/11',
+    // Armistice 1918
+    'armistice-1918'   => '11/11',
+    // Noël
+    'christmas'        => '25/12',
 ];


### PR DESCRIPTION
Comments were written on new lines **or** at the end of the lines. It was hard to read.