### PR TITLE
Add missing German holiday names

### DIFF
--- a/src/Cmixin/HolidayNames/de.php
+++ b/src/Cmixin/HolidayNames/de.php
@@ -86,4 +86,6 @@ return [
     'labor-day'                                       => 'Tag der Arbeit',
     'epiphany'                                        => 'Heilige Drei Könige',
     'children-s-day'                                  => 'Weltkindertag',
+    'german-unity-day'                                => 'Tag der Deutschen Einheit',
+    '08-15'                                           => 'Mariä Himmelfahrt',
 ];


### PR DESCRIPTION
The two names of German resp. Bavarian holidays were missing. The holidays themselves were already defined.