### PR TITLE
Add 'Muttertag' to Swiss German holiday names

### DIFF
--- a/src/Cmixin/HolidayNames/de.php
+++ b/src/Cmixin/HolidayNames/de.php
@@ -72,6 +72,7 @@ return [
     'constitution-day'                                => 'Tag des Grundgesetzes',
     'independence-day'                                => 'Unabhängigkeitstag',
     'mothers-day'                                     => 'Muttertag',
+    '2nd-sunday-in-may'                               => 'Muttertag',
     'national-holiday'                                => 'Nationalfeiertag',
     'reformation-day'                                 => 'Reformationstag',
     'substitutes'                                     => 'Ersatztag',


### PR DESCRIPTION
Included the Swiss German holiday name 'Muttertag' to the holiday list in src/Cmixin/HolidayNames/de.php file to present accurate and complete holiday names specific to Switzerland.