### PR TITLE
'easter' is only a public holiday in Brandenburg

### DIFF
--- a/src/Cmixin/Holidays/de-bb.php
+++ b/src/Cmixin/Holidays/de-bb.php
@@ -1,6 +1,7 @@
 <?php
 
 return array_replace(require __DIR__.'/de-national.php', [
+    'easter'          => '= easter',
     'easter-49'       => '= easter 49',
     'reformation-day' => '10-31',
 ]);

--- a/src/Cmixin/Holidays/de-national.php
+++ b/src/Cmixin/Holidays/de-national.php
@@ -3,7 +3,6 @@
 return [
     'new-year'                => '01-01',
     'easter-2'                => '= easter -2',
-    'easter'                  => '= easter',
     'easter-p1'               => '= easter 1',
     'labor-day'               => '05-01',
     'easter-39'               => '= easter 39',


### PR DESCRIPTION
`easter` is only a public holiday in Brandenburg and not throughout Germany.
Source:
https://www.ferienwiki.de/feiertage/ostersonntag
https://verdi-bub.de/wissen/urteile/ostersonntag-und-pfingstsonntag-sind-keine-gesetzlichen-feiertage