### PR TITLE
Add German One-time public holiday

### DIFF
--- a/src/Cmixin/Holidays/de-national.php
+++ b/src/Cmixin/Holidays/de-national.php
@@ -11,4 +11,5 @@ return [
     'german-unity-day'        => '10-03',
     'christmas'               => '12-25',
     'christmas-next-day'      => '12-26',
+    'reformation-day'         => '2017-10-31',
 ];


### PR DESCRIPTION
One-time public holiday in all states, including those not normally observing Reformation Day, to mark the 500th anniversary of the Reformation in 2017.

Source: https://en.wikipedia.org/wiki/Public_holidays_in_Germany#cite_ref-10