### PR TITLE
Easter -48 is not a holiday in Denmark

### DIFF
--- a/src/Cmixin/Holidays/dk-national.php
+++ b/src/Cmixin/Holidays/dk-national.php
@@ -2,7 +2,6 @@
 
 return [
     'new-year'            => '01-01',
-    'easter-48'           => '= easter -48',
     'easter-3'            => '= easter -3',
     'easter-2'            => '= easter -2',
     'easter'              => '= easter',


### PR DESCRIPTION
Easter -48 is not a holiday in Denmark

https://tlib.dk/kalender