### PR TITLE
Remove 12-24 as a National Australian Holiday

### DIFF
--- a/src/Cmixin/Holidays/au-national.php
+++ b/src/Cmixin/Holidays/au-national.php
@@ -8,7 +8,6 @@ return [
     'easter'             => '= easter',
     '04-25-and'          => '= 04-25 substitute',
     '2nd-monday-of-june' => '= second Monday of June',
-    '12-24'              => '12-24',
     '12-25-and'          => '= 12-25 if Saturday then next Monday',
     'substitutes-12-25'  => '= 12-25 if Sunday then next Tuesday',
     '12-26-and'          => '= 12-26 substitute',

--- a/src/Cmixin/Holidays/au-nt.php
+++ b/src/Cmixin/Holidays/au-nt.php
@@ -3,4 +3,5 @@
 return array_replace(require __DIR__.'/au-national.php', [
     '1st-monday-of-may'    => '= first Monday of May',
     '1st-monday-of-august' => '= first Monday of August',
+    '12-24-19:00'          => '= 12-24 19:00',
 ]);

--- a/src/Cmixin/Holidays/au-qld.php
+++ b/src/Cmixin/Holidays/au-qld.php
@@ -4,4 +4,5 @@ return array_replace(require __DIR__.'/au-national.php', [
     '1st-monday-of-october' => '= first Monday of October',
     '1st-monday-of-may'     => '= first Monday of May',
     '2nd-monday-of-june'    => null,
+    '12-24-18:00'           => '= 12-24 18:00',
 ]);


### PR DESCRIPTION
Running the following code shows that for the `au-national` holiday list, 12-24 is incorrectly flagged as a national holiday:

```php
Carbon::setHolidaysRegion('au-national');

foreach (Carbon::getYearHolidays(2025) as $id => $holiday) {
    echo $holiday->getHolidayName().': '.$holiday->format('l, F j, Y').'<br />';
}
```

Output:
```
Unknown: Wednesday, January 1, 2025
Unknown: Monday, January 27, 2025
Easter Tuesday: Friday, April 18, 2025
Easter Monday: Monday, April 21, 2025
Easter: Sunday, April 20, 2025
Unknown: Friday, April 25, 2025
Unknown: Monday, June 9, 2025
Washington's Birthday: Wednesday, December 24, 2025
Unknown: Thursday, December 25, 2025
Unknown: Thursday, December 25, 2025
Unknown: Friday, December 26, 2025
Unknown: Wednesday, December 31, 2025
```

Based off of https://data.gov.au/data/dataset/australian-holidays-machine-readable-dataset, this MR aims to remove 12-24 as a national holiday and move it to only the applicable states QLD, NT & SA (12-24 already present).