### PR TITLE
Add Christmas Eve to Polish National Holidays List

### DIFF
--- a/src/Cmixin/Holidays/pl-national.php
+++ b/src/Cmixin/Holidays/pl-national.php
@@ -13,6 +13,7 @@ return [
     '08-15'              => '08-15',
     '11-01'              => '11-01',
     'independence-day'   => '11-11',
+    'christmas-eve'      => '= 12-24 if year >= 2025',
     'christmas'          => '12-25',
     'christmas-next-day' => '12-26',
 ];

--- a/tests/Cmixin/Holidays/PlTest.php
+++ b/tests/Cmixin/Holidays/PlTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Cmixin\Holidays;
+
+use Cmixin\BusinessDay;
+use PHPUnit\Framework\TestCase;
+
+class PlTest extends TestCase
+{
+    const CARBON_CLASS = 'Carbon\Carbon';
+
+    protected function setUp(): void
+    {
+        BusinessDay::enable(static::CARBON_CLASS);
+        $carbon = static::CARBON_CLASS;
+        $carbon::resetHolidays();
+    }
+
+    public function testHolidays()
+    {
+        $carbon = static::CARBON_CLASS;
+        $carbon::resetHolidays();
+        $carbon::setHolidaysRegion('pl-national');
+
+        self::assertFalse($carbon::parse('2024-12-24')->isHoliday());
+        self::assertFalse($carbon::parse('2023-12-24')->isHoliday());
+        self::assertTrue($carbon::parse('2025-12-24')->isHoliday());
+        self::assertTrue($carbon::parse('2026-12-24')->isHoliday());
+    }
+}


### PR DESCRIPTION
Added Christmas Eve to Polish National Holidays List starting from 2025, as per recent legislative changes in Poland.

- [https://en.wikipedia.org/wiki/Public_holidays_in_Poland](https://en.wikipedia.org/wiki/Public_holidays_in_Poland)